### PR TITLE
fix: allows servers/description to be optional

### DIFF
--- a/Security Test Generator.postman_collection.json
+++ b/Security Test Generator.postman_collection.json
@@ -478,7 +478,7 @@
 									"pm.test('Schema has server/baseUrl defined', function(){\r",
 									"    const servers = schema.servers;\r",
 									"    pm.expect(servers).to.not.be.undefined;\r",
-									"    const serverToTest = servers.find(s => s.description.toLowerCase() == server.toLowerCase());\r",
+									"    const serverToTest = servers.find(s => s.description? s.description.toLowerCase() == server.toLowerCase() : true);\r",
 									"    pm.expect(serverToTest).to.not.be.undefined;\r",
 									"\r",
 									"    pm.expect(serverToTest).to.have.property('url');\r",


### PR DESCRIPTION
Currently you get an error if the servers/description field is blank.  This is optional according to the spec so this change allows for this field to be blank.